### PR TITLE
Improvements and bug fixes

### DIFF
--- a/custom_plugins/ddr_overlays/__init__.py
+++ b/custom_plugins/ddr_overlays/__init__.py
@@ -39,7 +39,7 @@ def initialize(rhapi):
     def ddr_overlays_homePage():
         return templating.render_template('ddr_overlay_index.html', serverInfo=None, getOption=rhapi.db.option, __=rhapi.__)
 
-    ### bar ###
+    ### live results ###
     @bp.route('/ddr_overlays/stream/results')
     def ddr_overlays_streamResults():
         return templating.render_template('stream/results.html', serverInfo=None, getOption=rhapi.db.option, __=rhapi.__, DEBUG=False)

--- a/custom_plugins/ddr_overlays/pages/ddr_overlay_index.html
+++ b/custom_plugins/ddr_overlays/pages/ddr_overlay_index.html
@@ -208,7 +208,7 @@
             <tr>
                 <td><a href="#" onclick='openDynamicLink(event, "/ddr_overlays/stream/last_heat")' class="link-primary link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover">{{ __("Last Heat")}} (1920x800)</a></td>
                 <td>Results of the last heat of elimination stage</td>
-                <td>Bracket type<br>Race class</td>
+                <td>Bracket type</td>
             </tr>
             <tr>
                 <td><a href="#" onclick='openDynamicLink(event, "/ddr_overlays/stream/next_up")' class="link-primary link-offset-2 link-underline-opacity-25 link-underline-opacity-100-hover">{{ __("Next Up")}} (1920x800)</a></td>

--- a/custom_plugins/ddr_overlays/pages/stream/brackets.html
+++ b/custom_plugins/ddr_overlays/pages/stream/brackets.html
@@ -50,6 +50,7 @@
     var data_dependencies = [
         'all_languages',
         'language',
+        'result_data',
         'pilot_data',
         'class_data',
         'heat_data',
@@ -57,6 +58,7 @@
 
     rotorhazard.show_messages = false;
 
+    var ddr_race_data;
     var ddr_pilot_data;
     var ddr_class_data;
     var ddr_heat_data;
@@ -83,6 +85,11 @@
 
         socket.on('race_scheduled', default_handler['race_scheduled']);
 
+        socket.on('result_data', function (msg) {
+            ddr_race_data = msg;
+            build_elimination_brackets('{{ bracket_type }}', '{{ class_id }}', ddr_pilot_data, ddr_heat_data, ddr_class_data, ddr_race_data);
+        });
+
         socket.on('pilot_data', function (msg) {
             rotorhazard.event.pilot_attributes = msg.attributes;
             rotorhazard.event.pilots = msg.pilots;
@@ -96,7 +103,6 @@
 
         socket.on('heat_data', function (msg) {
             ddr_heat_data = msg.heats;
-            build_elimination_brackets('{{ bracket_type }}', '{{ class_id }}', ddr_pilot_data, ddr_heat_data, ddr_class_data);
         });
 
         socket.on('heartbeat', default_handler['heartbeat']);

--- a/custom_plugins/ddr_overlays/pages/stream/brackets.html
+++ b/custom_plugins/ddr_overlays/pages/stream/brackets.html
@@ -88,7 +88,7 @@
             rotorhazard.event.pilots = msg.pilots;
             rotorhazard.options.pilotSort = msg.pilotSort;
             ddr_pilot_data = msg.pilots;    
-        }); 
+        });
 
         socket.on('class_data', function (msg) {
             ddr_class_data = msg.classes;

--- a/custom_plugins/ddr_overlays/pages/stream/last_heat.html
+++ b/custom_plugins/ddr_overlays/pages/stream/last_heat.html
@@ -51,9 +51,9 @@
         'pilot_data',
         'result_data',
         'heat_data',
-        'leaderboard',
         'class_data',
-        'race_status'
+        'leaderboard',
+        'race_status',
     ];
 
     rotorhazard.show_messages = false;
@@ -104,13 +104,6 @@
 
         socket.on('class_data', function (msg) {
             ddr_class_data = msg.classes;
-
-            Object.values(ddr_class_data).forEach(race_class => {
-                if (race_class.id == race_class_id) {
-                    console.log(race_class);
-                    race_class_name = race_class.name;
-                }
-            });
         });
 
         socket.on('race_status', default_handler['race_status']);
@@ -126,67 +119,76 @@
 
             var heat_number = 0;
             if (ddr_race_data != undefined) {
-                // reason for this: race.heat counts heats of every class
-                // we need the heat number inside the current class
-                var elimination_heats = ddr_race_data.heats_by_class[race_class_id];
-                for (let i = 0; i < elimination_heats.length; i++) {
-                    const this_heat = elimination_heats[i];
-                    if (elimination_heats[i] == race.heat) {
-                        heat_number = i+1;
+                // reason for this: race.heat counts heats of every class (as a global counter),
+                // we need the heat number with respect to its class
+                for (let class_id in ddr_race_data.heats_by_class) {
+                    heat_number = ddr_race_data.heats_by_class[class_id].indexOf(race.heat) + 1;
+                    if (heat_number != 0) {
+                        // class found, save data
+                        race_class_id = class_id;
+                        Object.values(ddr_class_data).forEach(race_class => {
+                            if (race_class.id == race_class_id) {
+                                race_class_name = race_class.name;
+                            }
+                        });
+                        break;
                     }
                 }
             } else if (ddr_heat_data != undefined) {
                 // alternative method if ddr_race_data is not available
-                for (let i = 0; i < ddr_heat_data.heats.length; i++) {
-                    const this_heat = ddr_heat_data.heats[i];
-                    if (this_heat.class_id == race_class_id) {
-                        ++heat_number;
-                        if (this_heat.id == race.heat) {
-                            break;
+                let current_heat = ddr_heat_data.heats.find(h => h.id == race.heat);
+                let heats_by_current_class = ddr_heat_data.heats
+                    .filter(h => h.class_id == current_heat.class_id)
+                    .map(h => h.id);
+                heat_number = heats_by_current_class.indexOf(race.heat) + 1;
+                if (heat_number != 0) {
+                    // class found, save data
+                    race_class_id = current_heat.class_id;
+                    Object.values(ddr_class_data).forEach(race_class => {
+                        if (race_class.id == race_class_id) {
+                            race_class_name = race_class.name;
                         }
-                    }
+                    });
                 }
             }
 
             if (heat_number != 0) {
-                // refresh only when the heat is finished
-                // corner case (quite useless but just for fun): if a heat has only one pilot, it doesn't generate the "Winner is <pilot>" status message at the end,
-                // hence the overlay is not updated :D
-                if (race.status_msg) {
-                    let heat_index = heat_number-1;
+                console.log("Found class id " + race_class_id + " (" + race_class_name + ")");
+                console.log("Found heat number " + heat_number);
 
-                    $('.curr_heat_title').html(race.displayname);
+                let heat_index = heat_number-1;
 
-                    $('#nextup_pilot_box').empty();
+                $('.curr_heat_title').html(race.displayname);
 
-                    var leaderboard_type = race.leaderboard.meta.primary_leaderboard;
-                    build_nextup(race.leaderboard[leaderboard_type], 'current', race.leaderboard.meta, ddr_pilot_data, true);
+                $('#nextup_pilot_box').empty();
 
-                    var bracket_format_info = bracket_formats[race_bracket_type];
+                var leaderboard_type = race.leaderboard.meta.primary_leaderboard;
+                build_nextup(race.leaderboard[leaderboard_type], 'current', race.leaderboard.meta, ddr_pilot_data, true);
 
-                    let is_winner_bracket = (bracket_format_info[heat_index].type == "winner");
-                    let is_final_heat = (heat_number >= bracket_format_info[bracket_format_info.length-1].number);
+                var bracket_format_info = bracket_formats[race_bracket_type];
 
-                    // the result is nicely placed for heats with four pilots
-                    if (is_final_heat) {
-                        $('#winner-cell').empty();
-                        $('#lower-cell').empty();
+                let is_winner_bracket = (bracket_format_info[heat_index].type == "winner") || (bracket_format_info[heat_index].type == "preliminary");
+                let is_final_heat = (heat_number >= bracket_format_info[bracket_format_info.length-1].number);
+
+                // the result is nicely placed for heats with four pilots
+                if (is_final_heat) {
+                    $('#winner-cell').empty();
+                    $('#lower-cell').empty();
+                } else {
+                    // left side
+                    if (bracket_format_info[heat_index].advance_to != undefined) {
+                        $('#winner-cell').text("Advance to Race " + bracket_format_info[heat_index].advance_to);
+                    } else if (is_winner_bracket) {
+                        $('#winner-cell').text("Advance to Winner Bracket");
                     } else {
-                        // left side
-                        if (bracket_format_info[heat_index].advance_to != undefined) {
-                            $('#winner-cell').text("Advance to Race " + bracket_format_info[heat_index].advance_to);
-                        } else if (is_winner_bracket) {
-                            $('#winner-cell').text("Advance to Winner Bracket");
-                        } else {
-                            $('#winner-cell').text("Advance to Lower Bracket");
-                        }
+                        $('#winner-cell').text("Advance to Lower Bracket");
+                    }
 
-                        // right side
-                        if (is_winner_bracket) {
-                            $('#lower-cell').text("Go to Lower Bracket");
-                        } else {
-                            $('#lower-cell').text("Eliminated");
-                        }
+                    // right side
+                    if (is_winner_bracket) {
+                        $('#lower-cell').text("Go to Lower Bracket");
+                    } else {
+                        $('#lower-cell').text("Eliminated");
                     }
                 }
             }
@@ -199,7 +201,7 @@
         socket.on('stop_timer', default_handler['stop_timer']);
     });
 
-    let race_class_id = '{{ class_id }}';
+    let race_class_id; // do not use '{ class id }' from URL, it is computed automatically
     let race_class_name;
     let race_bracket_type = '{{ bracket_type }}';
 
@@ -214,7 +216,7 @@
         </div>
 
         <div id="title">
-            <span class="curr_heat_title"></span> - 
+            <span class="curr_heat_title"></span>
             <span class="curr_event_name">{{ getOption('eventName') }}</span>
         </div>
 
@@ -235,13 +237,13 @@
 
                 <div class="nextup_pilot_avatar">
                     <div class="nextup_pilot_avatar_mask">
-                        <img src="/ddr/static/imgs/no-avatar.webp" alt="Avatar">
+                        <img src="/ddr_overlays/static/imgs/no_avatar.png" alt="Avatar">
                     </div>
                 </div>
 
                 <div class="nextup_pilot_flag">
                     <div class="nextup_pilot_flag_mask">
-                        <img src="/ddr/static/imgs/flags/nl.jpg">
+                        <img src="/ddr_overlays/static/imgs/flags/nl.jpg">
                     </div>
                 </div>
 

--- a/custom_plugins/ddr_overlays/pages/stream/leaderboard_pages.html
+++ b/custom_plugins/ddr_overlays/pages/stream/leaderboard_pages.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="RotorHazard">
     <meta name="google" content="notranslate">
-    <title>Leaderboard Fullscreen</title>
+    <title>Leaderboard Pages</title>
 
     <!-- Icons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/static/image/apple-touch-icon.png">

--- a/custom_plugins/ddr_overlays/pages/stream/next_up.html
+++ b/custom_plugins/ddr_overlays/pages/stream/next_up.html
@@ -49,13 +49,19 @@
         'all_languages',
         'language',
         'pilot_data',
+        'result_data',
+        'heat_data',
+        'class_data',
         'leaderboard',
-        'race_status'
+        'race_status',
     ];
 
     rotorhazard.show_messages = false;
 
     var ddr_pilot_data;
+    var ddr_race_data;
+    var ddr_heat_data;
+    var ddr_class_data;
 
     function race_kickoff(msg) {
         rotorhazard.timer.stopAll();
@@ -91,6 +97,18 @@
             ddr_pilot_data = msg.pilots;    
         });
 
+        socket.on('result_data', function (msg) {
+            ddr_race_data = msg;
+        });
+
+        socket.on('heat_data', function (msg) {
+            ddr_heat_data = msg;
+        });
+
+        socket.on('class_data', function (msg) {
+            ddr_class_data = msg.classes;
+        });
+
         socket.on('heartbeat', default_handler['heartbeat']);
 
         socket.on('leaderboard', function (msg) {
@@ -121,7 +139,7 @@
         </div>
 
         <div id="title">
-            <span class="curr_heat_title"></span> - 
+            <span class="curr_heat_title"></span>
             <span class="curr_event_name">{{ getOption('eventName') }}</span>
         </div>
 
@@ -131,13 +149,13 @@
 
                 <div class="nextup_pilot_avatar">
                     <div class="nextup_pilot_avatar_mask">
-                        <img src="/ddr/static/imgs/no-avatar.webp" alt="Avatar">
+                        <img src="/ddr_overlays/static/imgs/no_avatar.png" alt="Avatar">
                     </div>
                 </div>
 
                 <div class="nextup_pilot_flag">
                     <div class="nextup_pilot_flag_mask">
-                        <img src="/ddr/static/imgs/flags/nl.jpg">
+                        <img src="/ddr_overlays/static/imgs/flags/nl.jpg">
                     </div>
                 </div>
 

--- a/custom_plugins/ddr_overlays/pages/stream/node.html
+++ b/custom_plugins/ddr_overlays/pages/stream/node.html
@@ -200,11 +200,8 @@
                     if (rotorhazard.event.pilots[pilot].pilot_id == pilot_id) {
 
                         pilot = rotorhazard.event.pilots[pilot];
-
-                        if (pilot.country) {
-                            country_flag = '<img class="country_flag" src="' + getFlagURL(pilot_id, msg.pilots) + '">';
-                            $('#node_flag').html(country_flag);
-                        }
+                        country_flag = '<img class="country_flag" src="' + getFlagURL(pilot_id, msg.pilots) + '">';
+                        $('#node_flag').html(country_flag);
 
                         break;
                     }
@@ -259,7 +256,7 @@
 
                         var pilotImg = getPilotImgURL(pilot_data);
 
-                        if (pilotNodeImg !== pilotImg && pilotImg !== '/ddr_overlays/static/imgs/no_avatar.png') {
+                        if (pilotNodeImg !== pilotImg) {
                             pilotNodeImg = pilotImg;
                             document.getElementById('node_avatar_img').src = pilotImg;
                         }

--- a/custom_plugins/ddr_overlays/pages/stream/node.html
+++ b/custom_plugins/ddr_overlays/pages/stream/node.html
@@ -202,8 +202,7 @@
                         pilot = rotorhazard.event.pilots[pilot];
 
                         if (pilot.country) {
-                            country_upper = pilot.country;
-                            country_flag = '<img class="country_flag" src="/ddr_overlays/static/imgs/flags/' + country_upper + '.jpg">';
+                            country_flag = '<img class="country_flag" src="' + getFlagURL(pilot_id, msg.pilots) + '">';
                             $('#node_flag').html(country_flag);
                         }
 
@@ -258,11 +257,7 @@
                         // $('#laps').html(pilot_data.laps);
                         // $('#fastest_lap').html(pilot_data.fastest_lap);
 
-                        var pilotImg = '/static/user/avatars/' + pilot_data.callsign.replace(/ /g,"_").toLowerCase() + '.jpg';
-
-                        if (!imageExists(pilotImg)) {
-                            pilotImg = '/ddr_overlays/static/imgs/no_avatar.png';
-                        }
+                        var pilotImg = getPilotImgURL(pilot_data);
 
                         if (pilotNodeImg !== pilotImg && pilotImg !== '/ddr_overlays/static/imgs/no_avatar.png') {
                             pilotNodeImg = pilotImg;

--- a/custom_plugins/ddr_overlays/pages/stream/node.html
+++ b/custom_plugins/ddr_overlays/pages/stream/node.html
@@ -185,9 +185,6 @@
             }
 
             var pilotNodeImg = '';
-
-            var pilot_attributes;
-            var curr_pilot_flag;
             var country_flag;
 
             /* Pilots */

--- a/custom_plugins/ddr_overlays/pages/stream/results.html
+++ b/custom_plugins/ddr_overlays/pages/stream/results.html
@@ -80,11 +80,6 @@
 
         socket.on('language', default_handler['language']);
 
-        // set up node local store
-        //for (i = 0; i < {{ num_nodes }}; i++) {
-        //    rotorhazard.nodes[i] = new nodeModel();
-        //}
-
         socket.on('race_scheduled', default_handler['race_scheduled']);
 
         socket.on('race_status', default_handler['race_status']);
@@ -129,12 +124,18 @@
                     if (current_laps.node_index[j].pilot?.callsign == this_callsign) {
                         for (var k in current_laps.node_index[j].laps) {
                             var this_lap = current_laps.node_index[j].laps[k];
-                            pilot_to_laps[this_callsign] += this_lap.lap_time + "<br/>";
+                            if (k == 0) {
+                                // hole shot
+                                pilot_to_laps[this_callsign] += "[" + this_lap.lap_time + "]<br/>";
+                            } else {
+                                // regular lap
+                                pilot_to_laps[this_callsign] += this_lap.lap_time + "<br/>";
+                            }
                         }
                         break;
                     }
                 }
-                $('#leaderboard td.laps').eq(i).html(pilot_to_laps[this_callsign] ? pilot_to_laps[this_callsign] : "—");
+                $('#leaderboard td.laps').eq(i).html(pilot_to_laps[this_callsign] || "—");
             }
             
             $('#team_leaderboard').empty();

--- a/custom_plugins/ddr_overlays/static/css/ddr_overlays.css
+++ b/custom_plugins/ddr_overlays/static/css/ddr_overlays.css
@@ -209,7 +209,6 @@ h1, h2, h3, h4, h5 {
     float: left;
     margin-right: 12px;
     box-shadow: 0 0 0px 2px #fff;
-
 }
 
 #ddr_node #node_info_bar #node_race_stats {

--- a/custom_plugins/ddr_overlays/static/js/ddr_overlays.js
+++ b/custom_plugins/ddr_overlays/static/js/ddr_overlays.js
@@ -172,7 +172,6 @@ function build_nextup(leaderboard, display_type, meta, ddr_pilot_data, show_posi
     }
 
     for (var i in leaderboard) {
-
         let pilot_name = leaderboard[i].callsign;       
         let flagImg = getFlagURL(leaderboard[i].pilot_id, ddr_pilot_data);
         let pilotImg = getPilotImgURL(leaderboard[i]);
@@ -269,7 +268,7 @@ function build_leaderboard(leaderboard, display_type, meta, number_of_pilots=999
         if (i < number_of_pilots) {
             var row = $('<tr id="pilot_id_' + leaderboard[i].pilot_id + '">');
 
-            row.append('<td class="pos">'+ (leaderboard[i].position != null ? leaderboard[i].position : '-') +'</td>');
+            row.append('<td class="pos">'+ (leaderboard[i].position || '-') +'</td>');
 
             var pilotImg = getPilotImgURL(leaderboard[i]);
             row.append('<td class="avatar"><img src=" ' + pilotImg + ' "></td>');
@@ -310,9 +309,9 @@ function build_leaderboard(leaderboard, display_type, meta, number_of_pilots=999
                 row.append('<td class="avg">'+ lap +'</td>');
             }
             if (display_type == 'by_fastest_lap' ||
-            display_type == 'heat' ||
-            display_type == 'round' ||
-            display_type == 'current') {
+                display_type == 'heat' ||
+                display_type == 'round' ||
+                display_type == 'current') {
                 var lap = leaderboard[i].fastest_lap;
                 if (!lap || lap == '0:00.000')
                     lap = '&#8212;';
@@ -338,9 +337,9 @@ function build_leaderboard(leaderboard, display_type, meta, number_of_pilots=999
                 }
             }
             if (display_type == 'by_consecutives' ||
-            display_type == 'heat' ||
-            display_type == 'round' ||
-            display_type == 'current') {
+                display_type == 'heat' ||
+                display_type == 'round' ||
+                display_type == 'current') {
                 var data = leaderboard[i];
                 if (!data.consecutives || data.consecutives == '0:00.000') {
                     lap = '&#8212;';
@@ -386,7 +385,11 @@ function build_leaderboard(leaderboard, display_type, meta, number_of_pilots=999
 
 /* Pilot data retrieval */
 function getFlagURL(pilot_id, ddr_pilot_data) {
-    return '/ddr_overlays/static/imgs/flags/' + getPilotFlag(pilot_id, ddr_pilot_data) + '.jpg';
+    let flagImg = '/ddr_overlays/static/imgs/flags/' + getPilotFlag(pilot_id, ddr_pilot_data) + '.png';
+    if (!imageExists(flagImg)) {
+        flagImg = '/ddr_overlays/static/imgs/flags/it.png';
+    }
+    return flagImg;
 }
 
 function getPilotFlag(pilot_id, ddr_pilot_data) {
@@ -397,8 +400,6 @@ function getPilotFlag(pilot_id, ddr_pilot_data) {
             pilot = ddr_pilot_data[i];
             if (pilot.country) {
                 country_upper = pilot.country;
-                //country_flag = '<img class="country_flag" src="/fpvscores/static/assets/imgs/flags/'+country_upper+'.jpg">';
-                //$('#pilot_flag').html(country_flag);
                 return country_upper;
             }
             break;
@@ -474,55 +475,55 @@ class BracketHeat {
 
 const bracket_formats = {
     "multigp16": [
-                   new BracketHeat(1,  "winner", 0, 6),
-                   new BracketHeat(2,  "winner", 0, 6),
-                   new BracketHeat(3,  "winner", 0, 8),
-                   new BracketHeat(4,  "winner", 0, 8),
-                   new BracketHeat(5,  "loser",  0, 9),
-                   new BracketHeat(6,  "winner", 1, 11),
-                   new BracketHeat(7,  "loser",  0, 10),
-                   new BracketHeat(8,  "winner", 1, 11),
-                   new BracketHeat(9,  "loser",  1, 12),
-                   new BracketHeat(10, "loser",  1, 12),
-                   new BracketHeat(11, "winner", 2, 14),
-                   new BracketHeat(12, "loser",  2, 13),
-                   new BracketHeat(13, "loser",  3, 14),
-                   new BracketHeat(14, "winner", 3),
+                   new BracketHeat(1,  "preliminary", 0, 6),
+                   new BracketHeat(2,  "preliminary", 0, 6),
+                   new BracketHeat(3,  "preliminary", 0, 8),
+                   new BracketHeat(4,  "preliminary", 0, 8),
+                   new BracketHeat(5,  "loser",       0, 9),
+                   new BracketHeat(6,  "winner",      1, 11),
+                   new BracketHeat(7,  "loser",       0, 10),
+                   new BracketHeat(8,  "winner",      1, 11),
+                   new BracketHeat(9,  "loser",       1, 12),
+                   new BracketHeat(10, "loser",       1, 12),
+                   new BracketHeat(11, "winner",      2, 14),
+                   new BracketHeat(12, "loser",       2, 13),
+                   new BracketHeat(13, "loser",       3, 14),
+                   new BracketHeat(14, "winner",      3),
                  ],
     //"fai16":     [],
     //"fai16de":   [],
     //"fai32":     [],
     "fai32de":   [
-                   new BracketHeat(1,  "winner", 0),
-                   new BracketHeat(2,  "winner", 0),
-                   new BracketHeat(3,  "winner", 0),
-                   new BracketHeat(4,  "winner", 0),
-                   new BracketHeat(5,  "winner", 1),
-                   new BracketHeat(6,  "winner", 1),
-                   new BracketHeat(7,  "winner", 1),
-                   new BracketHeat(8,  "winner", 1),
-                   new BracketHeat(9,  "winner", 2),
-                   new BracketHeat(10, "winner", 2),
-                   new BracketHeat(11, "winner", 2),
-                   new BracketHeat(12, "winner", 2),
-                   new BracketHeat(13, "loser",  0),
-                   new BracketHeat(14, "loser",  0),
-                   new BracketHeat(15, "loser",  0),
-                   new BracketHeat(16, "loser",  0),
-                   new BracketHeat(17, "loser",  1),
-                   new BracketHeat(18, "loser",  1),
-                   new BracketHeat(19, "loser",  1),
-                   new BracketHeat(20, "loser",  1),
-                   new BracketHeat(21, "loser",  2),
-                   new BracketHeat(22, "loser",  2),
-                   new BracketHeat(23, "winner", 3),
-                   new BracketHeat(24, "winner", 3),
-                   new BracketHeat(25, "loser",  3),
-                   new BracketHeat(26, "loser",  3),
-                   new BracketHeat(27, "loser",  4),
-                   new BracketHeat(28, "winner", 4),
-                   new BracketHeat(29, "loser",  5),
-                   new BracketHeat(30, "winner", 5),
+                   new BracketHeat(1,  "preliminary", 0),
+                   new BracketHeat(2,  "preliminary", 0),
+                   new BracketHeat(3,  "preliminary", 0),
+                   new BracketHeat(4,  "preliminary", 0),
+                   new BracketHeat(5,  "preliminary", 1),
+                   new BracketHeat(6,  "preliminary", 1),
+                   new BracketHeat(7,  "preliminary", 1),
+                   new BracketHeat(8,  "preliminary", 1),
+                   new BracketHeat(9,  "winner",      2),
+                   new BracketHeat(10, "winner",      2),
+                   new BracketHeat(11, "winner",      2),
+                   new BracketHeat(12, "winner",      2),
+                   new BracketHeat(13, "loser",       0),
+                   new BracketHeat(14, "loser",       0),
+                   new BracketHeat(15, "loser",       0),
+                   new BracketHeat(16, "loser",       0),
+                   new BracketHeat(17, "loser",       1),
+                   new BracketHeat(18, "loser",       1),
+                   new BracketHeat(19, "loser",       1),
+                   new BracketHeat(20, "loser",       1),
+                   new BracketHeat(21, "loser",       2),
+                   new BracketHeat(22, "loser",       2),
+                   new BracketHeat(23, "winner",      3),
+                   new BracketHeat(24, "winner",      3),
+                   new BracketHeat(25, "loser",       3),
+                   new BracketHeat(26, "loser",       3),
+                   new BracketHeat(27, "loser",       4),
+                   new BracketHeat(28, "winner",      4),
+                   new BracketHeat(29, "loser",       5),
+                   new BracketHeat(30, "winner",      5),
                  ],
     //"fai64":     [],
     //"fai64de":   []
@@ -565,7 +566,7 @@ function build_elimination_brackets(race_bracket_type, race_class_id, ddr_pilot_
                     html += '</div>';
                 }
             } else {
-                let flagImg = getFlagURL(slot.pilot_id, ddr_pilot_data);
+                let flagImg = getFlagURL(pilot.pilot_id, ddr_pilot_data);
                 let pilotImg = getPilotImgURL(pilot);
 
                 html += '<div class="bracket_race_pilot">';
@@ -584,7 +585,7 @@ function build_elimination_brackets(race_bracket_type, race_class_id, ddr_pilot_
         if (bracket_formats[race_bracket_type] != undefined) {
             let bracket_heat_info = bracket_formats[race_bracket_type][i];
 
-            if (bracket_heat_info.type == "winner") {
+            if (bracket_heat_info.type == "winner" || bracket_heat_info.type == "preliminary") {
                 var column_counter = bracket_heat_info.column; 
                 if ($('#bracket_column_' + column_counter).length == 0) {
                     $('#winner_bracket_content').append('<div id="bracket_column_'+column_counter+'" class="bracket_column"></div>');

--- a/custom_plugins/ddr_overlays/static/js/ddr_overlays.js
+++ b/custom_plugins/ddr_overlays/static/js/ddr_overlays.js
@@ -533,7 +533,7 @@ const bracket_formats = {
     //"fai64de":   []
 }
 
-function build_elimination_brackets(race_bracket_type, race_class_id, ddr_pilot_data, ddr_heat_data, ddr_class_data) {
+function build_elimination_brackets(race_bracket_type, race_class_id, ddr_pilot_data, ddr_heat_data, ddr_class_data, ddr_race_data) {
 
     // clear brackets
     $('#winner_bracket_content').html('');
@@ -560,16 +560,21 @@ function build_elimination_brackets(race_bracket_type, race_class_id, ddr_pilot_
 
         for (let j = 0; j < filtered_slots.length; j++) {
             const slot = filtered_slots[j];
-            const pilot = ddr_pilot_data.find(p => p.pilot_id === slot.pilot_id);           
+            let pilot;
 
             if (slot.pilot_id === 0) {
-                if (slot.method > -1 && !(slot.method == 0 && !slot.pilot_id)) {
-                    var method_text = get_method_descriptor(ddr_pilot_data, ddr_heat_data, ddr_class_data, slot.method, slot.seed_id, slot.seed_rank, slot.pilot_id)
-                    html += '<div class="bracket_race_pilot">';
-                    html += '<div class="no_pilot">' + method_text + '</div>';
-                    html += '</div>';
+                // try to get the pilot from completed heats
+                if (slot.method == 1) {
+                    // heat
+                    const leaderboard_type = ddr_race_data.heats[slot.seed_id]?.leaderboard.meta.primary_leaderboard;
+                    pilot = ddr_race_data.heats[slot.seed_id]?.leaderboard[leaderboard_type].find(p => p.position === slot.seed_rank);
                 }
             } else {
+                // pilot available
+                pilot = ddr_pilot_data.find(p => p.pilot_id === slot.pilot_id);
+            }
+
+            if (pilot) {
                 let flagImg = getFlagURL(pilot.pilot_id, ddr_pilot_data);
                 let pilotImg = getPilotImgURL(pilot);
 
@@ -579,6 +584,11 @@ function build_elimination_brackets(race_bracket_type, race_class_id, ddr_pilot_
                 html += '<div class="flag"><img src="' + flagImg + '" alt="USA"></div>';
                 html += '<div class="pilot_name">' + pilot.callsign + '</div>';
 
+                html += '</div>';
+            } else {
+                let method_text = get_method_descriptor(ddr_pilot_data, ddr_heat_data, ddr_class_data, slot.method, slot.seed_id, slot.seed_rank, slot.pilot_id)
+                html += '<div class="bracket_race_pilot">';
+                html += '<div class="no_pilot">' + method_text + '</div>';
                 html += '</div>';
             }
         }

--- a/custom_plugins/ddr_overlays/static/js/ddr_overlays.js
+++ b/custom_plugins/ddr_overlays/static/js/ddr_overlays.js
@@ -389,9 +389,9 @@ function build_leaderboard(leaderboard, display_type, meta, number_of_pilots=999
 
 /* Pilot data retrieval */
 function getFlagURL(pilot_id, ddr_pilot_data) {
-    let flagImg = '/ddr_overlays/static/imgs/flags/' + getPilotFlag(pilot_id, ddr_pilot_data) + '.png';
+    let flagImg = '/ddr_overlays/static/imgs/flags/' + getPilotFlag(pilot_id, ddr_pilot_data) + '.jpg';
     if (!imageExists(flagImg)) {
-        flagImg = '/ddr_overlays/static/imgs/flags/it.png';
+        flagImg = '/ddr_overlays/static/imgs/flags/it.jpg';
     }
     return flagImg;
 }
@@ -413,7 +413,7 @@ function getPilotFlag(pilot_id, ddr_pilot_data) {
 }
 
 function getPilotImgURL(pilot) {
-    let pilotImg = '/static/user/avatars/' + pilot.callsign.replace(/ /g,"_").toLowerCase() + '.jpg';      
+    let pilotImg = '/static/user/avatars/' + pilot.callsign.replace(/ /g,"_").toLowerCase() + '.jpg';
     if (!imageExists(pilotImg)) {
         pilotImg = '/ddr_overlays/static/imgs/no_avatar.png';
     }

--- a/custom_plugins/ddr_overlays/static/js/ddr_overlays.js
+++ b/custom_plugins/ddr_overlays/static/js/ddr_overlays.js
@@ -286,9 +286,9 @@ function build_leaderboard(leaderboard, display_type, meta, number_of_pilots=999
                 row.append('<td class="starts">' + leaderboard[i].starts + '</td>');
             }
             if (display_type == 'by_race_time' ||
-            display_type == 'heat' ||
-            display_type == 'round' ||
-            display_type == 'current') {
+                display_type == 'heat' ||
+                display_type == 'round' ||
+                display_type == 'current') {
                 var lap = leaderboard[i].laps;
                 if (!lap || lap == '0:00.000')
                     lap = '&#8212;';
@@ -296,15 +296,18 @@ function build_leaderboard(leaderboard, display_type, meta, number_of_pilots=999
 
                 if (meta.start_behavior == 2) {
                     var lap = leaderboard[i].total_time_laps;
+                    var lap_raw = leaderboard[i].total_time_laps_raw;
                 } else {
                     var lap = leaderboard[i].total_time;
+                    var lap_raw = leaderboard[i].total_time_raw;
                 }
-                if (!lap || lap == '0:00.000')
+                if (!lap_raw || lap_raw == 0)
                     lap = '&#8212;';
                 row.append('<td class="total">'+ lap +'</td>');
 
                 var lap = leaderboard[i].average_lap;
-                if (!lap || lap == '0:00.000')
+                var lap_raw = leaderboard[i].average_lap_raw;
+                if (!lap_raw || lap_raw == 0)
                     lap = '&#8212;';
                 row.append('<td class="avg">'+ lap +'</td>');
             }
@@ -313,7 +316,8 @@ function build_leaderboard(leaderboard, display_type, meta, number_of_pilots=999
                 display_type == 'round' ||
                 display_type == 'current') {
                 var lap = leaderboard[i].fastest_lap;
-                if (!lap || lap == '0:00.000')
+                var lap_raw = leaderboard[i].fastest_lap_raw;
+                if (!lap_raw || lap_raw == 0)
                     lap = '&#8212;';
 
                 var el = $('<td class="fast">'+ lap +'</td>');
@@ -341,7 +345,7 @@ function build_leaderboard(leaderboard, display_type, meta, number_of_pilots=999
                 display_type == 'round' ||
                 display_type == 'current') {
                 var data = leaderboard[i];
-                if (!data.consecutives || data.consecutives == '0:00.000') {
+                if (!data.consecutives_raw || data.consecutives_raw == 0) {
                     lap = '&#8212;';
                 } else {
                     lap = data.consecutives_base + '/' + data.consecutives;
@@ -604,7 +608,7 @@ function build_elimination_brackets(race_bracket_type, race_class_id, ddr_pilot_
 
 function get_method_descriptor(ddr_pilot_data, ddr_heat_data, ddr_class_data, method, seed, rank, pilot_id) {
     if (method == 0) { // pilot
-        var pilot =  ddr_pilot_data?.find(obj => {return obj.pilot_id == pilot_id});
+        var pilot = ddr_pilot_data?.find(obj => {return obj.pilot_id == pilot_id});
 
         if (pilot) {
             return pilot.callsign;
@@ -630,3 +634,12 @@ function get_method_descriptor(ddr_pilot_data, ddr_heat_data, ddr_class_data, me
     }
     return false;
 }
+
+
+
+/* utility functions */
+function setsAreEqual(set1, set2) {
+    if (set1.size !== set2.size) return false;
+    return [...set1].every(item => set2.has(item));
+}
+


### PR DESCRIPTION
Improvements:
* Page 'last_heat' can identify the class ID autonomously from the current heat ID. The user does not need to explicitly indicate the class ID through the URL.
* Added compatibility to custom time formats if the user decides to show lap times with a format different from the default {m}:{s}.{ms}
* The bracket diagram is now filled with pilots under each heat as soon as they are qualified to that heat, without the need to wait until that heat is run. For example, at the end of Race 1 in a MultiGP-de session, first two slots of Race 5 and first two slots of Race 6 are already filled.

Bug fixes:
* Fixed a bug in page 'node' that causes the visualization of the wrong pilot avatar in some circumstances.